### PR TITLE
Changed the default operation names for better visibility

### DIFF
--- a/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/TracingKafkaTest.java
+++ b/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/TracingKafkaTest.java
@@ -160,10 +160,10 @@ public class TracingKafkaTest {
       assertEquals(parent.context().traceId(), span.context().traceId());
     }
 
-    MockSpan sendSpan = getByOperationName(mockSpans, "send");
+    MockSpan sendSpan = getByOperationName(mockSpans, TracingKafkaUtils.TO_PREFIX + "messages");
     assertNotNull(sendSpan);
 
-    MockSpan receiveSpan = getByOperationName(mockSpans, "receive");
+    MockSpan receiveSpan = getByOperationName(mockSpans, TracingKafkaUtils.FROM_PREFIX + "messages");
     assertNotNull(receiveSpan);
 
     assertEquals(sendSpan.context().spanId(), receiveSpan.parentId());
@@ -250,10 +250,10 @@ public class TracingKafkaTest {
   private void checkSpans(List<MockSpan> mockSpans) {
     for (MockSpan mockSpan : mockSpans) {
       String operationName = mockSpan.operationName();
-      if (operationName.equals("send")) {
+      if (operationName.equals(TracingKafkaUtils.TO_PREFIX + "messages")) {
         assertEquals(Tags.SPAN_KIND_PRODUCER, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         assertEquals("messages", mockSpan.tags().get(Tags.MESSAGE_BUS_DESTINATION.getKey()));
-      } else if (operationName.equals("receive")) {
+      } else if (operationName.equals(TracingKafkaUtils.FROM_PREFIX + "messages")) {
         assertEquals(Tags.SPAN_KIND_CONSUMER, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         assertEquals(0, mockSpan.tags().get("partition"));
         long offset = (Long) mockSpan.tags().get("offset");
@@ -262,8 +262,8 @@ public class TracingKafkaTest {
       }
       assertEquals(SpanDecorator.COMPONENT_NAME, mockSpan.tags().get(Tags.COMPONENT.getKey()));
       assertEquals(0, mockSpan.generatedErrors().size());
-      assertTrue(operationName.equals("send")
-          || operationName.equals("receive"));
+      assertTrue(operationName.equals(TracingKafkaUtils.TO_PREFIX + "messages")
+          || operationName.equals(TracingKafkaUtils.FROM_PREFIX + "messages"));
     }
   }
 

--- a/opentracing-kafka-streams/src/test/java/io/opentracing/contrib/kafka/streams/TracingKafkaStreamsTest.java
+++ b/opentracing-kafka-streams/src/test/java/io/opentracing/contrib/kafka/streams/TracingKafkaStreamsTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import io.opentracing.contrib.kafka.TracingKafkaProducer;
+import io.opentracing.contrib.kafka.TracingKafkaUtils;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
@@ -107,11 +108,11 @@ public class TracingKafkaStreamsTest {
   private void checkSpans(List<MockSpan> mockSpans) {
     for (MockSpan mockSpan : mockSpans) {
       String operationName = mockSpan.operationName();
-      if (operationName.equals("send")) {
+      if (operationName.equals(TracingKafkaUtils.TO_PREFIX + "stream-test")) {
         assertEquals(Tags.SPAN_KIND_PRODUCER, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         String topicName = (String) mockSpan.tags().get(Tags.MESSAGE_BUS_DESTINATION.getKey());
         assertTrue(topicName.equals("stream-out") || topicName.equals("stream-test"));
-      } else if (operationName.equals("receive")) {
+      } else if (operationName.equals(TracingKafkaUtils.FROM_PREFIX + "stream-test")) {
         assertEquals(Tags.SPAN_KIND_CONSUMER, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         assertEquals(0, mockSpan.tags().get("partition"));
         long offset = (Long) mockSpan.tags().get("offset");
@@ -121,8 +122,10 @@ public class TracingKafkaStreamsTest {
       }
       assertEquals("java-kafka", mockSpan.tags().get(Tags.COMPONENT.getKey()));
       assertEquals(0, mockSpan.generatedErrors().size());
-      assertTrue(operationName.equals("send")
-          || operationName.equals("receive"));
+      assertTrue(operationName.equals(TracingKafkaUtils.TO_PREFIX + "stream-test")
+          || operationName.equals(TracingKafkaUtils.FROM_PREFIX + "stream-test")
+          || operationName.equals(TracingKafkaUtils.FROM_PREFIX + "stream-out")
+          || operationName.equals(TracingKafkaUtils.TO_PREFIX + "stream-out"));
     }
   }
 


### PR DESCRIPTION
This PR changes the way how tracing calls producer and consumer operation names. Currently, if it is a producer the tracing uses _send_ as operation name, and if it is a consumer it uses _receive_. That may work well with small transactions where there are a single producer and a single consumer, but when there are multiple processing stages (Topic A > Topic B > Topic C... Topic N) it might be a little difficult to understand the ordering of things in the Jaeger UI.

This is particularly important when developers make use of the Streams API and KSQL, where there will be multiple stages of processing, with different topics involved. The PR addresses this problem by using the following notation:

- If it is a **producer**, then it uses "To_" + Topic
- If it is a **consumer**, then it uses "From_" + Topic

The picture below shows an example of this PR:

![image](https://user-images.githubusercontent.com/35476/53305427-8cf5c680-384f-11e9-8e5b-366dc5f44edb.png)
